### PR TITLE
Initial prompt addition for PoC 2

### DIFF
--- a/BRcommands.py
+++ b/BRcommands.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+# Set of commands recognized by Bad Reader
+# Author : Heartbroken-Dev
+# License : Apache License 2.0
+# Version : PoC 2
+
+from time import sleep
+from smartcard.util import toHexString
+
+# While I wrap my head around Abstract classes for Python let's assume all classes are "well-made"
+
+class Disconnect:
+
+    helpDesc = "disconnect : disconnects the current card, giving the user five (5) seconds to remove the currently plugged in card before reattempting connection."
+
+    def execute(cardService, cmdList):
+        print("Disconnecting card...")
+        cardService.connection.disconnect() # TODO : should be checked to have worked if possible
+        print("Successfully disconnected !") # TODO : Green ?
+        sleep(5)
+
+class Exit:
+
+    helpDesc = "exit : neatly closes the prompt, disconnecting the current card beforehand if need be."
+
+    def execute(cardService, cmdList):
+        raise NotImplementedError # empty function, currently all done in main
+
+class Help:
+
+    helpDesc = "help : displays this help message."
+
+    def execute(cardService, cmdList):
+        print('\t' + Disconnect.helpDesc)
+        print('\t' + Exit.helpDesc)
+        print('\t' + Help.helpDesc)
+        print('\t' + GetATR.helpDesc)
+
+class GetATR:
+
+    helpDesc = "getATR : prints out the current card's Answer To Reset."
+
+    def execute(cardService, cmdList):
+        print(toHexString(cardService.connection.getATR()))

--- a/BRutils.py
+++ b/BRutils.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+
+# Set of utility functions, variables or constants used by Bad Reader
+# Author : Heartbroken-Dev
+# License : Apache License 2.0
+# Version : Proof of concept
+
+# Pseudo constants
+class const:
+	
+	# Statuses for the prompt
+	STATUS_PROMPT_DISCONNECTED = 10
+	STATUS_PROMPT_EXITING = 20
+	

--- a/BRutils.py
+++ b/BRutils.py
@@ -3,12 +3,11 @@
 # Set of utility functions, variables or constants used by Bad Reader
 # Author : Heartbroken-Dev
 # License : Apache License 2.0
-# Version : Proof of concept
+# Version : PoC 2
 
 # Pseudo constants
 class const:
-	
+
 	# Statuses for the prompt
 	STATUS_PROMPT_DISCONNECTED = 10
 	STATUS_PROMPT_EXITING = 20
-	

--- a/BadReader.py
+++ b/BadReader.py
@@ -11,7 +11,8 @@ from smartcard.CardType import AnyCardType
 from smartcard.CardRequest import CardRequest
 from smartcard.util import toHexString 
 from smartcard.Exceptions import CardRequestTimeoutException
-from time import sleep
+from BRutils import const
+# from time import sleep
 
 def attemptConnection(cardRequest):
 
@@ -19,7 +20,7 @@ def attemptConnection(cardRequest):
 	
 	print("Waiting for card insertion", flush=True, end='')
 	
-	while(stillWaiting):
+	while stillWaiting:
 		try:
 			stillWaiting = False
 			print(".", flush=True, end='')
@@ -37,6 +38,9 @@ def attemptConnection(cardRequest):
 	
 	return cardService	
 
+def enterPrompt(cardService):
+	# TODO
+
 def main():
 	
 	mainCardType = AnyCardType()
@@ -46,14 +50,21 @@ def main():
 	print("Bad Reader, PoC")
 	print("By Heartbroken-Dev, licensed under Apache-2.0")
 
-	# Attempt to connect to a card
-	mainCardService = attemptConnection(mainCardRequest)
+	while True: # Pseudo do: .. while()
+	
+		# Attempt to connect to a card
+		mainCardService = attemptConnection(mainCardRequest)
+		
+		promptStatus = enterPrompt(mainCardService)
+		
+		if promptStatus == STATUS_PROMPT_EXITING:
+			break
 
 	# automatic disconnecting for PoC test
-	print("Now disconnecting in 5 s")
-	sleep(5)
-	mainCardService.connection.disconnect()
-	print("Card disconnected, can now be safely removed")
+	# print("Now disconnecting in 5 s")
+	# sleep(5)
+	# mainCardService.connection.disconnect()
+	# print("Card disconnected, can now be safely removed")
 	
 if __name__ == '__main__':
 	main()

--- a/BadReader.py
+++ b/BadReader.py
@@ -12,6 +12,32 @@ from smartcard.CardRequest import CardRequest
 from smartcard.util import toHexString 
 from smartcard.Exceptions import CardRequestTimeoutException
 from time import sleep
+import BRcommands as cmds
+
+def enterPrompt(cardService):
+	requestedExit = False
+	requestedDisconnect = False
+	cardATR = cardService.connection.getATR() # to be protected by try..except clause if cardService not connected
+	
+	while not requestedExit:
+
+		cmdIn = input(cardATR + " >>> ") # or any other prompt-like thing
+		cmdList = cmdIn.split()
+
+		if cmdList[0] == "disconnect":
+			requestedDisconnect = True
+			requestedExit = True # Required to exit the prompt for reconnection as is
+			cmds.disconnect(cardService)
+		elif cmdList[0] == "exit":
+			if not requestedDisconnect:
+				print("Disconnecting card before exiting") # Yellow ?
+				cmds.disconnect(cardService)
+			print("Exiting")
+			requestedExit = True
+		elif cmdList[0] == "getATR":
+			cmds.getATR(cardService)
+		else: # default to help()
+			cmds.help()
 
 def attemptConnection(cardRequest):
 


### PR DESCRIPTION
First integration of a prompt-like interface with 4 working commands

Commands include :
- `disconnect`
- `exit`
- `help`
- `getATR`

This means that the `dev` branch should be ready to be considered PoC 2 worthy once tested a bit more.