### PR TITLE
Addition of the operations requiring transmission to and from the card

### DIFF
--- a/BRutils.py
+++ b/BRutils.py
@@ -36,6 +36,5 @@ class apdu:
 	READ_PROTECTION_BITS = [0xFF,0xB2,0x00,0x00,0x04]
 	WRITE_MEMORY_CARD = [0xFF,0xD0,0x00] # + byte address of first byte to write + length of data to write (in bytes ?) + every byte to write
 	WRITE_PROTECTION_MEMORY_CARD = [0xFF,0xD1,0x00] # + byte address of first byte to write (from 0x00 to 0x1F) + length of data to write (in bytes ?) + every byte to write
-	PRESENT_CODE_MEMORY_CARD = [0xFF,0x20,0x00,0x00,0x03] + # + each of the three bytes of the PIN
+	PRESENT_CODE_MEMORY_CARD = [0xFF,0x20,0x00,0x00,0x03] # + each of the three bytes of the PIN
 	CHANGE_CODE_MEMORY_CARD = [0xFF,0xD2,0x00,0x01,0x03] # + each of the three bytes of the new PIN
-	

--- a/BRutils.py
+++ b/BRutils.py
@@ -26,3 +26,16 @@ class const:
 	# Statuses for the prompt
 	STATUS_PROMPT_DISCONNECTED = 10
 	STATUS_PROMPT_EXITING = 20
+
+## @brief Class containing APDUs to transmit
+#  @sa https://hashtips.files.wordpress.com/2013/10/pma-acr38xccid-6-02.pdf
+class apdu:
+	SELECT_CARD_TYPE = [0xFF,0xA4,0x00,0x00,0x01,0x06]
+	READ_MEMORY_CARD = [0xFF,0xB0,0x00] # + byte address of first byte to read + length of data to read (in bytes ?)
+	READ_PRESENTATION_ERROR_COUNTER_MEMORY_CARD = [0xFF,0xB1,0x00,0x00,0x04]
+	READ_PROTECTION_BITS = [0xFF,0xB2,0x00,0x00,0x04]
+	WRITE_MEMORY_CARD = [0xFF,0xD0,0x00] # + byte address of first byte to write + length of data to write (in bytes ?) + every byte to write
+	WRITE_PROTECTION_MEMORY_CARD = [0xFF,0xD1,0x00] # + byte address of first byte to write (from 0x00 to 0x1F) + length of data to write (in bytes ?) + every byte to write
+	PRESENT_CODE_MEMORY_CARD = [0xFF,0x20,0x00,0x00,0x03] + # + each of the three bytes of the PIN
+	CHANGE_CODE_MEMORY_CARD = [0xFF,0xD2,0x00,0x01,0x03] # + each of the three bytes of the new PIN
+	

--- a/BadReader.py
+++ b/BadReader.py
@@ -50,16 +50,23 @@ def enterPrompt(cardService):
 			requestedDisconnect = True
 			requestedExit = True # Required to exit the prompt for reconnection as is
 			cmds.Disconnect.execute(cardService, cmdList)
+
 		elif cmdList[0] == "exit":
 			if not requestedDisconnect:
 				print("Disconnecting card before exiting") # TODO : Yellow ?
 				cmds.Disconnect.execute(cardService, cmdList)
 			print("Exiting")
 			requestedExit = True
+
 		elif cmdList[0] == "getATR":
 			cmds.GetATR.execute(cardService, cmdList)
+
 		elif cmdList[0] == "read":
 			cmds.Read.execute(cardService, cmdList)
+
+		elif cmdList[0] == "verify":
+			cmds.Verify.execute(cardService, cmdList)
+			
 		else: # default to help()
 			cmds.Help.execute(cardService, cmdList) # TODO : add specific message when there's a typo ?
 

--- a/BadReader.py
+++ b/BadReader.py
@@ -58,6 +58,8 @@ def enterPrompt(cardService):
 			requestedExit = True
 		elif cmdList[0] == "getATR":
 			cmds.GetATR.execute(cardService, cmdList)
+		elif cmdList[0] == "read":
+			cmds.Read.execute(cardService, cmdList)
 		else: # default to help()
 			cmds.Help.execute(cardService, cmdList) # TODO : add specific message when there's a typo ?
 


### PR DESCRIPTION
This PR aims at adding the first "complicated" operations to *BadReader*. These require transmission and interpretation of APDUs.
A standard that actually works with the set of card is required. Then once this is acquired the following operations should be implemented to go with `v1.0.0-alpha`'s goals.

To do:
- [x] Find a standard for the APDUs
  - Followed this [technical manual](https://hashtips.files.wordpress.com/2013/10/pma-acr38xccid-6-02.pdf)'s naming standard
- [x] `read` command
- [ ] `verify` command
- [ ] `write` command
- [ ] `change` command